### PR TITLE
add minimum-stability in root composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "autoload": {
         "psr-0": { "": "src/", "SymfonyStandard": "app/" }
     },
+    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",
         "symfony/symfony": "2.6.*",


### PR DESCRIPTION
Avoid this error on composer install

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for symfonyid/admin-bundle dev-master -> satisfiable by symfonyid/admin-bundle[dev-master].
    - symfonyid/admin-bundle dev-master requires friendsofsymfony/user-bundle 2.0.x-dev -> no matching package found.
  Problem 2
    - symfonyid/admin-bundle dev-master requires friendsofsymfony/user-bundle 2.0.x-dev -> no matching package found.
    - symfony/framework-standard-edition 2.6.x-dev requires symfonyid/admin-bundle dev-master -> satisfiable by symfonyid/admin-bundle[dev-master].
    - Installation request for symfony/framework-standard-edition 2.6.x-dev -> satisfiable by symfony/framework-standard-edition[2.6.x-dev].

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion> for more details.
```